### PR TITLE
Move access tokens to HTTP-only cookies

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "buffer": "^6.0.3",
-    "jwt-decode": "^4.0.0",
     "libsignal-protocol": "file:src/crypto/libsignal-protocol",
     "node-forge": "^1.3.1",
     "react": "18.3.1",
@@ -22,8 +21,8 @@
     "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.0.4",
     "@playwright/test": "^1.50.0",
+    "@vitejs/plugin-react": "^4.0.4",
     "vite": "^6.3.5"
   }
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,22 +8,32 @@ import LoginPage from './pages/LoginPage';
 import { RegisterPage } from './pages/RegisterPage';
 
 function Protected({ children }) {
-  const { token } = useContext(AuthContext);
-  if (!token) {
+  const { isAuthenticated, initialised } = useContext(AuthContext);
+  if (!initialised) {
+    return null;
+  }
+  if (!isAuthenticated) {
     return <Navigate to="/login" replace />;
   }
   return children;
 }
 
 export default function App() {
-  const { token } = useContext(AuthContext);
+  const { isAuthenticated, initialised } = useContext(AuthContext);
+
+  if (!initialised) {
+    return null;
+  }
 
   return (
     <Routes>
-      <Route path="/login" element={token ? <Navigate to="/chat" replace /> : <LoginPage />} />
+      <Route
+        path="/login"
+        element={isAuthenticated ? <Navigate to="/chat" replace /> : <LoginPage />}
+      />
       <Route
         path="/register"
-        element={token ? <Navigate to="/chat" replace /> : <RegisterPage />}
+        element={isAuthenticated ? <Navigate to="/chat" replace /> : <RegisterPage />}
       />
       <Route
         path="/chat"
@@ -44,7 +54,7 @@ export default function App() {
           </Protected>
         }
       />
-      <Route path="*" element={<Navigate to={token ? '/chat' : '/login'} replace />} />
+      <Route path="*" element={<Navigate to={isAuthenticated ? '/chat' : '/login'} replace />} />
     </Routes>
   );
 }

--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -63,6 +63,8 @@ export async function history(chatId, options = {}) {
 const api = {
   register: (data) => request('/api/auth/register', 'POST', data),
   login: (data) => request('/api/auth/login', 'POST', data),
+  logout: () => request('/api/auth/logout', 'POST'),
+  session: () => request('/api/auth/session'),
   uploadBundle: (bundle) => request('/api/keybundle', 'POST', bundle),
   getBundle,
   sendMessage,

--- a/client/src/api/request.js
+++ b/client/src/api/request.js
@@ -1,26 +1,5 @@
 // client/src/api/request.js
 const ABSOLUTE_URL = /^https?:\/\//i;
-
-let accessToken = null;
-
-export function setAccessToken(token) {
-  accessToken = token || null;
-}
-
-export function clearAccessToken() {
-  accessToken = null;
-}
-
-export function getAccessToken() {
-  if (accessToken) {
-    return accessToken;
-  }
-  if (typeof globalThis !== 'undefined' && typeof globalThis.__ACCESS_TOKEN__ === 'string') {
-    return globalThis.__ACCESS_TOKEN__;
-  }
-  return null;
-}
-
 function resolveUrl(path) {
   if (ABSOLUTE_URL.test(path)) {
     return path;
@@ -37,15 +16,10 @@ function resolveUrl(path) {
 
 export async function request(url, method = 'GET', body) {
   const resolvedUrl = resolveUrl(url);
-  const opts = { method, headers: {} };
+  const opts = { method, headers: {}, credentials: 'include' };
   if (body !== undefined && body !== null) {
     opts.headers['Content-Type'] = 'application/json';
     opts.body = JSON.stringify(body);
-  }
-
-  const token = getAccessToken();
-  if (token) {
-    opts.headers.Authorization = `Bearer ${token}`;
   }
 
   const res = await fetch(resolvedUrl, opts);

--- a/client/src/contexts/AuthContext.jsx
+++ b/client/src/contexts/AuthContext.jsx
@@ -1,104 +1,94 @@
-import { jwtDecode } from 'jwt-decode';
-import React, { createContext, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { api } from '../api/api';
-import { clearAccessToken, getAccessToken, setAccessToken } from '../api/request.js';
 import { resetSignalState } from '../crypto/signal';
 
 export const AuthContext = createContext();
 
-const TOKEN_CLOCK_SKEW_SEC = 5;
-
-function decodeAccessToken(token) {
-  if (!token) {
-    return null;
-  }
-  try {
-    const payload = jwtDecode(token);
-    const now = Math.floor(Date.now() / 1000);
-    if (typeof payload.exp === 'number' && payload.exp <= now) {
-      return null;
-    }
-    if (typeof payload.nbf === 'number' && payload.nbf > now + TOKEN_CLOCK_SKEW_SEC) {
-      return null;
-    }
-    return payload;
-  } catch (err) {
-    console.warn('Failed to decode access token', err);
-    return null;
-  }
-}
-
-function getUserIdFromPayload(payload) {
-  if (!payload || typeof payload !== 'object') {
-    return null;
-  }
-  return payload.userId || payload.sub || payload.id || null;
-}
-
 export function AuthProvider({ children }) {
-  const initialSession = useMemo(() => {
-    const storedToken = getAccessToken();
-    const payload = decodeAccessToken(storedToken);
-    const resolvedUserId = getUserIdFromPayload(payload);
-    if (!storedToken || !payload || !resolvedUserId) {
-      clearAccessToken();
-      return { token: null, userId: null };
-    }
-    return { token: storedToken, userId: resolvedUserId };
-  }, []);
-  const [token, setToken] = useState(initialSession.token);
-  const [userId, setUserId] = useState(initialSession.userId);
+  const [userId, setUserId] = useState(null);
   const [error, setError] = useState('');
+  const [initialised, setInitialised] = useState(false);
   const navigate = useNavigate();
 
-  const setSession = (nextToken, explicitUserId) => {
-    if (!nextToken) {
-      clearAccessToken();
-      setToken(null);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const session = await api.session();
+        if (!cancelled && session?.userId) {
+          setUserId(session.userId);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          console.warn('Failed to restore session', err);
+          setUserId(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setInitialised(true);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const login = useCallback(async (creds) => {
+    setError('');
+    try {
+      const { userId: issuedUserId } = await api.login(creds);
+      setUserId(issuedUserId);
+      setInitialised(true);
+      return issuedUserId;
+    } catch (err) {
+      setError('Не удалось выполнить вход.');
+      throw err;
+    }
+  }, []);
+
+  const register = useCallback(async (data) => {
+    setError('');
+    try {
+      const { userId: issuedUserId } = await api.register(data);
+      setUserId(issuedUserId);
+      setInitialised(true);
+      return issuedUserId;
+    } catch (err) {
+      setError('Не удалось завершить регистрацию.');
+      throw err;
+    }
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      await api.logout();
+    } catch (err) {
+      console.warn('Failed to call logout endpoint', err);
+    } finally {
       setUserId(null);
-      return null;
+      resetSignalState();
+      navigate('/login');
     }
+  }, [navigate]);
 
-    const payload = decodeAccessToken(nextToken);
-    if (!payload) {
-      throw new Error('Invalid or expired access token received');
-    }
-
-    const resolvedUserId = explicitUserId ?? getUserIdFromPayload(payload);
-    if (!resolvedUserId) {
-      throw new Error('Access token is missing a user identifier');
-    }
-
-    setAccessToken(nextToken);
-    setToken(nextToken);
-    setUserId(resolvedUserId);
-    return resolvedUserId;
-  };
-
-  const login = async (creds) => {
-    setError('');
-    const { token: issuedToken, userId: issuedUserId } = await api.login(creds);
-    return setSession(issuedToken, issuedUserId);
-  };
-
-  const register = async (data) => {
-    setError('');
-    const { token: issuedToken, userId: issuedUserId } = await api.register(data);
-    return setSession(issuedToken, issuedUserId);
-  };
-
-  const logout = () => {
-    clearAccessToken();
-    setToken(null);
-    setUserId(null);
-    resetSignalState();
-    navigate('/login');
-  };
+  const value = useMemo(
+    () => ({
+      userId,
+      isAuthenticated: Boolean(userId),
+      error,
+      login,
+      register,
+      logout,
+      initialised,
+    }),
+    [userId, error, login, register, logout, initialised]
+  );
 
   return (
-    <AuthContext.Provider value={{ token, userId, error, login, register, logout }}>
+    <AuthContext.Provider value={value}>
       {children}
     </AuthContext.Provider>
   );

--- a/client/src/pages/ChatPage.jsx
+++ b/client/src/pages/ChatPage.jsx
@@ -9,7 +9,7 @@ import { AuthContext } from '../contexts/AuthContext';
 import { initSession, decryptMessage } from '../crypto/signal.js';
 
 export default function ChatPage() {
-  const { token, userId, logout } = useContext(AuthContext);
+  const { isAuthenticated, userId, logout } = useContext(AuthContext);
   const { chatId: routeChatId } = useParams();
 
   const chatId = useMemo(() => routeChatId, [routeChatId]);
@@ -83,7 +83,7 @@ export default function ChatPage() {
   useEffect(() => {
     setJoinError('');
     setJoinedRoom(false);
-    if (!token || !sessionReady) return undefined;
+    if (!isAuthenticated || !sessionReady) return undefined;
 
     const configuredUrl = (import.meta.env.VITE_API_URL || '').trim();
     const fallbackOrigin =
@@ -134,7 +134,7 @@ export default function ChatPage() {
     };
 
     const socket = io(resolvedUrl, {
-      auth: { token },
+      withCredentials: true,
     });
 
     let cancelled = false;
@@ -198,7 +198,7 @@ export default function ChatPage() {
       socket.off('disconnect', disconnectHandler);
       socket.disconnect();
     };
-  }, [chatId, logout, sessionReady, token]);
+  }, [chatId, logout, sessionReady, isAuthenticated]);
 
   const handleSend = async (plainText) => {
     if (!sessionReady || !plainText || !joinedRoom) return;

--- a/docs/API.md
+++ b/docs/API.md
@@ -7,16 +7,27 @@
 ### POST /api/auth/register
 
 - Тело: `{ username, email, password, publicKey }`
-- Ответ: `201 { token, userId }`
+- Ответ: `201 { userId }` + `Set-Cookie: access_token=...; HttpOnly`
 - Ошибки: `400 missing_fields`, `400 user_exists`
   【F:server/src/routes/auth.js†L9-L32】
 
 ### POST /api/auth/login
 
 - Тело: `{ email, password }`
-- Ответ: `200 { token, userId }`
+- Ответ: `200 { userId }` + `Set-Cookie: access_token=...; HttpOnly`
 - Ошибки: `400 invalid_credentials`
   【F:server/src/routes/auth.js†L34-L44】
+
+### POST /api/auth/logout
+
+- Очищает cookie сессии, возвращает `204 No Content`
+  【F:server/src/routes/auth.js†L136-L144】
+
+### GET /api/auth/session
+
+- Ответ: `200 { userId }` при валидном cookie `access_token`
+- Ошибки: `401 unauthorized`
+  【F:server/src/routes/auth.js†L146-L157】
 
 ### POST /api/keybundle
 
@@ -50,7 +61,7 @@
 
 ## Socket.IO
 
-- Хендшейк: `Authorization: Bearer <JWT>` заголовок или `auth.token`.
+- Хендшейк: браузерные клиенты автоматически отправляют cookie `access_token`. Также поддерживается `Authorization: Bearer <JWT>` или `auth.token`.
 - События:
   - `join { chatId }` → ack `{ ok: true }` при участии в чате, иначе `{ ok: false, error }`.
   - `message { id, chatId, senderId, encryptedPayload, createdAt }` — рассылается после записи в БД.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,7 @@
 ```mermaid
 graph TD
   A[Client (React + WebCrypto + Signal Worker)] -->|REST /auth,/keybundle,/messages| B[Server (Express)]
-  A -->|Socket.IO (JWT)| B
+  A -->|Socket.IO (JWT cookie)| B
   B -->|ciphertext only| C[(MongoDB)]
   B -->|replay digests| D[(Redis)]
 ```
@@ -46,7 +46,7 @@ sequenceDiagram
   DB-->>S: [{ chatId, senderId, encryptedPayload, createdAt }]
   S-->>U: ciphertext history (base64)
   U->>U: decryptMessage(encryptedPayload)
-  U->>IO: connect (Authorization: Bearer JWT)
+  U->>IO: connect (cookie access_token)
   IO->>S: verify JWT
   S-->>IO: socket.data.userId = sub
   U->>S: emit join { chatId }

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -27,7 +27,7 @@ Redis хранит `replay:{chatId}:{sha256(payload)}` с TTL, что предо
 
 ## Socket.IO
 
-- Хендшейк требует JWT из заголовка Authorization; при невалидном токене соединение отклоняется.【F:server/src/app.js†L78-L115】
+- Хендшейк считывает JWT из HttpOnly cookie `access_token`, но остаётся обратная совместимость с заголовком Authorization/`auth.token`; невалидные значения приводят к отказу подключения.【F:server/src/app.js†L193-L236】
 - После проверки пользователь может присоединиться только к комнатам чатов, участником которых является, иначе возвращается ошибка `forbidden`.【F:server/src/app.js†L115-L142】【F:server/src/models/Chat.js†L1-L24】
 
 ## Ограничения и известные риски

--- a/load/processors.js
+++ b/load/processors.js
@@ -1,10 +1,31 @@
 'use strict';
+
 module.exports = { seedIfNeeded, genCipher };
+
 const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-function randomB64(n=256){ let s=''; for(let i=0;i<n;i++) s+=chars[(Math.random()*chars.length)|0]; return s; }
+
+function randomB64(length = 256) {
+  let result = '';
+  for (let i = 0; i < length; i += 1) {
+    const index = Math.floor(Math.random() * chars.length);
+    result += chars[index];
+  }
+  return result;
+}
+
 async function seedIfNeeded(ctx, events, done) {
-  if (process.env.VERIFY_MODE === '1') { try { await fetch('http://127.0.0.1:3000/__test__/bootstrap'); } catch {} }
+  if (process.env.VERIFY_MODE === '1') {
+    try {
+      await fetch('http://127.0.0.1:3000/__test__/bootstrap');
+    } catch (err) {
+      console.warn('failed to prime bootstrap endpoint', err);
+    }
+  }
   ctx.vars.chatId = process.env.ART_CHAT_ID || 'chat-1';
   return done();
 }
-function genCipher(ctx, events, done){ ctx.vars.b64 = randomB64(512); return done(); }
+
+function genCipher(ctx, events, done) {
+  ctx.vars.b64 = randomB64(512);
+  return done();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@noble/curves": "^1.6.0",
         "@noble/hashes": "^1.4.0",
         "artillery": "^2.0.11",
+        "c8": "^10.1.3",
         "cross-env": "^7.0.3",
         "eslint": "^9.12.0",
         "eslint-plugin-import": "^2.31.0",
@@ -32,7 +33,6 @@
       "version": "0.0.0",
       "dependencies": {
         "buffer": "^6.0.3",
-        "jwt-decode": "^4.0.0",
         "libsignal-protocol": "file:src/crypto/libsignal-protocol",
         "node-forge": "^1.3.1",
         "react": "18.3.1",
@@ -1504,6 +1504,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "dev": true,
@@ -2341,6 +2351,119 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -3802,6 +3925,17 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@playwright/browser-chromium": {
       "version": "1.54.2",
       "dev": true,
@@ -4838,6 +4972,13 @@
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
       "dev": true,
       "license": "MIT"
     },
@@ -6062,6 +6203,251 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/c8": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
+      "integrity": "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.1",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^7.0.1",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "monocart-coverage-reports": "^2"
+      },
+      "peerDependenciesMeta": {
+        "monocart-coverage-reports": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/c8/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/c8/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/c8/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/c8/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/c8/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/c8/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/c8/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/c8/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/c8/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/c8/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/c8/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/c8/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/c8/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/c8/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/c8/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -7309,6 +7695,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -8653,6 +9046,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "3.0.4",
       "dev": true,
@@ -9119,6 +9529,13 @@
     },
     "node_modules/hpagent": {
       "version": "0.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
     },
@@ -9875,6 +10292,100 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jake": {
       "version": "10.9.4",
       "dev": true,
@@ -10052,13 +10563,6 @@
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jwt-decode": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/kareem": {
@@ -10839,6 +11343,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mitt": {
@@ -11780,6 +12294,13 @@
         "node": ">= 14"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "dev": true,
@@ -11887,6 +12408,30 @@
       "version": "1.0.7",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
@@ -13502,6 +14047,55 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
       "dev": true,
@@ -13576,6 +14170,30 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
@@ -13786,6 +14404,68 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-decoder": {
@@ -14303,6 +14983,21 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "license": "MIT",
@@ -14663,6 +15358,109 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -11,12 +11,13 @@ import { Server as SocketIOServer } from 'socket.io';
 import config from './config.js';
 import { requestIdLogger } from './logger.js';
 import { httpMetrics, metricsHandler, wireWsMetrics, incWsAuthFailed } from './metrics.js';
-import authMiddleware, { verifyJwt } from './middleware/auth.js';
+import authMiddleware, { verifyJwt, getSharedSecret } from './middleware/auth.js';
 import Chat from './models/Chat.js';
 import authRouter from './routes/auth.js';
 import buildKeybundleRouter from './routes/keybundle.js';
 import messagesRouter from './routes/messages.js';
 import { mountTestBootstrap } from './test/bootstrap.routes.js';
+import { parseCookies, COOKIE_NAME } from './util/accessTokenCookie.js';
 
 export async function connectMongo(uri) {
   const configuredUri =
@@ -96,6 +97,17 @@ export function createApp({
 
   const pass = (req, _res, next) => next();
   const auth = overrideAuth || authMiddleware || pass;
+
+  if (!overrideAuth) {
+    try {
+      getSharedSecret();
+    } catch (err) {
+      logger.error?.('jwt_secret_validation_failed', err);
+      const error = new Error('JWT shared secret misconfigured');
+      error.cause = err;
+      throw error;
+    }
+  }
 
   const perUserLimiter = expressRateLimit({
     windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000),
@@ -181,7 +193,10 @@ export function attachSockets(server, { cors: corsOptions } = {}) {
       const header = socket.handshake.headers?.authorization;
       const tokenFromHeader =
         typeof header === 'string' && header.startsWith('Bearer ') ? header.slice(7) : undefined;
-      const token = tokenFromHeader || socket.handshake.auth?.token;
+      const cookieHeader = socket.handshake.headers?.cookie;
+      const cookies = parseCookies(cookieHeader);
+      const cookieToken = cookies.get(COOKIE_NAME);
+      const token = tokenFromHeader || socket.handshake.auth?.token || cookieToken;
       if (!token) {
         incWsAuthFailed();
         return next(new Error('unauthorized'));
@@ -189,6 +204,9 @@ export function attachSockets(server, { cors: corsOptions } = {}) {
 
       const userId = verifySocketToken(token, { audience, issuer });
       socket.data.user = { id: userId };
+      if (cookieToken) {
+        socket.data.cookieToken = cookieToken;
+      }
       socket.data.reauthAttempts = [];
       return next();
     } catch {
@@ -223,14 +241,17 @@ export function attachSockets(server, { cors: corsOptions } = {}) {
         if (attempts.length >= REAUTH_MAX_ATTEMPTS) {
           throw new Error('rate_limited');
         }
-        if (typeof accessToken !== 'string' || !accessToken) {
+        const providedToken =
+          typeof accessToken === 'string' && accessToken ? accessToken : socket.data.cookieToken;
+        if (typeof providedToken !== 'string' || !providedToken) {
           throw new Error('invalid_token');
         }
         attempts.push(now);
         socket.data.reauthAttempts = attempts;
 
-        const nextUserId = verifySocketToken(accessToken, { audience, issuer });
+        const nextUserId = verifySocketToken(providedToken, { audience, issuer });
         socket.data.user = { id: nextUserId };
+        socket.data.cookieToken = providedToken;
 
         const rooms = [...socket.rooms].filter((room) => room !== socket.id);
         await Promise.all(

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -2,6 +2,7 @@
 import jwt from 'jsonwebtoken';
 
 import config from '../config.js';
+import { extractAccessToken } from '../util/accessTokenCookie.js';
 
 const JWT_ALG = Object.freeze({
   RS256: 'RS256',
@@ -102,8 +103,7 @@ export function verifyAccess(token) {
 
 export function authRequired(req, res, next) {
   try {
-    const hdr = req.headers.authorization || '';
-    const token = hdr.startsWith('Bearer ') ? hdr.slice(7) : '';
+    const token = extractAccessToken(req);
     req.user = verifyAccess(token);
     return next();
   } catch {

--- a/server/src/routes/keybundle.js
+++ b/server/src/routes/keybundle.js
@@ -2,30 +2,114 @@ import { Router } from 'express';
 import mongoose from 'mongoose';
 
 import KeyBundle from '../models/KeyBundle.js';
-import base64Regex from '../util/base64Regex.js';
+import sanitizeBase64 from '../util/sanitizeBase64.js';
 
-function validateOneTimePreKeys(items) {
-  if (!Array.isArray(items)) {
-    return false;
+const MIN_KEY_B64_LEN = 16;
+const MAX_KEY_B64_LEN = 512;
+const MAX_SIGNATURE_B64_LEN = 1024;
+const MAX_IDENTITY_KEY_BYTES = 256;
+const MAX_SIGNED_PREKEY_BYTES = 256;
+const MAX_SIGNATURE_BYTES = 512;
+const MAX_ONE_TIME_PRE_KEY_BYTES = 256;
+
+function sanitizeIdentityKey(value) {
+  return sanitizeBase64(value, {
+    minLength: MIN_KEY_B64_LEN,
+    maxLength: MAX_KEY_B64_LEN,
+    maxBytes: MAX_IDENTITY_KEY_BYTES,
+  });
+}
+
+function sanitizeSignedPreKey(value) {
+  if (!value || typeof value !== 'object') {
+    return null;
   }
+
+  const { keyId, publicKey, signature } = value;
+  if (!Number.isInteger(keyId) || keyId < 0) {
+    return null;
+  }
+
+  const sanitizedPublicKey = sanitizeBase64(publicKey, {
+    minLength: MIN_KEY_B64_LEN,
+    maxLength: MAX_KEY_B64_LEN,
+    maxBytes: MAX_SIGNED_PREKEY_BYTES,
+  });
+  const sanitizedSignature = sanitizeBase64(signature, {
+    minLength: MIN_KEY_B64_LEN,
+    maxLength: MAX_SIGNATURE_B64_LEN,
+    maxBytes: MAX_SIGNATURE_BYTES,
+  });
+
+  if (!sanitizedPublicKey || !sanitizedSignature) {
+    return null;
+  }
+
+  return { keyId, publicKey: sanitizedPublicKey, signature: sanitizedSignature };
+}
+
+function resolveMaxOneTimePreKeys() {
+  const raw = process.env.KEYBUNDLE_MAX_PREKEYS ?? process.env.KEYBUNDLE_PREKEY_LIMIT;
+  if (typeof raw === 'string' && raw.trim().length > 0) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return Math.min(parsed, 500);
+    }
+  }
+  return 200;
+}
+
+function sanitizeOneTimePreKeys(items) {
+  if (!Array.isArray(items)) {
+    return null;
+  }
+
+  const maxPreKeys = resolveMaxOneTimePreKeys();
+  if (items.length > maxPreKeys) {
+    return null;
+  }
+
+  const seenKeyIds = new Set();
+  const seenPublicKeys = new Set();
+  const sanitized = [];
 
   for (const entry of items) {
-    if (typeof entry !== 'object' || entry === null) {
-      return false;
+    if (!entry || typeof entry !== 'object') {
+      return null;
     }
 
-    const { keyId, publicKey } = entry;
-
+    const { keyId } = entry;
     if (!Number.isInteger(keyId) || keyId < 0) {
-      return false;
+      return null;
     }
 
-    if (typeof publicKey !== 'string' || publicKey.length === 0 || !base64Regex.test(publicKey)) {
-      return false;
+    const sanitizedPublicKey = sanitizeBase64(entry.publicKey, {
+      minLength: MIN_KEY_B64_LEN,
+      maxLength: MAX_KEY_B64_LEN,
+      maxBytes: MAX_ONE_TIME_PRE_KEY_BYTES,
+    });
+    if (!sanitizedPublicKey) {
+      return null;
+    }
+
+    if (seenKeyIds.has(keyId) || seenPublicKeys.has(sanitizedPublicKey)) {
+      continue;
+    }
+
+    seenKeyIds.add(keyId);
+    seenPublicKeys.add(sanitizedPublicKey);
+    sanitized.push({ keyId, publicKey: sanitizedPublicKey });
+
+    if (sanitized.length > maxPreKeys) {
+      return null;
     }
   }
 
-  return true;
+  if (sanitized.length === 0) {
+    return null;
+  }
+
+  return sanitized;
 }
 
 export default function keybundleRouter(auth) {
@@ -38,7 +122,11 @@ export default function keybundleRouter(auth) {
       return res.status(400).json({ error: 'invalid_payload' });
     }
 
-    if (!validateOneTimePreKeys(oneTimePreKeys)) {
+    const sanitizedIdentityKey = sanitizeIdentityKey(identityKey);
+    const sanitizedSignedPreKey = sanitizeSignedPreKey(signedPreKey);
+    const sanitizedOneTimePreKeys = sanitizeOneTimePreKeys(oneTimePreKeys);
+
+    if (!sanitizedIdentityKey || !sanitizedSignedPreKey || sanitizedOneTimePreKeys === null) {
       return res.status(400).json({ error: 'invalid_payload' });
     }
 
@@ -47,15 +135,21 @@ export default function keybundleRouter(auth) {
         { userId },
         {
           userId,
-          identityKey,
-          signedPreKey,
-          oneTimePreKeys: oneTimePreKeys.map((k) => ({
+          identityKey: sanitizedIdentityKey,
+          signedPreKey: sanitizedSignedPreKey,
+          oneTimePreKeys: sanitizedOneTimePreKeys.map((k) => ({
             keyId: k.keyId,
             publicKey: k.publicKey,
             used: false,
           })),
         },
-        { upsert: true, new: true, setDefaultsOnInsert: true, runValidators: true, context: 'query' }
+        {
+          upsert: true,
+          new: true,
+          setDefaultsOnInsert: true,
+          runValidators: true,
+          context: 'query',
+        }
       );
       return res.sendStatus(204);
     } catch (err) {

--- a/server/src/util/accessTokenCookie.js
+++ b/server/src/util/accessTokenCookie.js
@@ -1,0 +1,87 @@
+import jwt from 'jsonwebtoken';
+
+const COOKIE_NAME = 'access_token';
+
+function isSecureEnv() {
+  const env = (process.env.NODE_ENV || '').toLowerCase();
+  return env === 'production' || env === 'staging';
+}
+
+export function parseCookies(header) {
+  const map = new Map();
+  if (typeof header !== 'string' || header.length === 0) {
+    return map;
+  }
+
+  const pairs = header.split(';');
+  for (const pair of pairs) {
+    const index = pair.indexOf('=');
+    if (index === -1) {
+      continue;
+    }
+    const name = pair.slice(0, index).trim();
+    if (!name) {
+      continue;
+    }
+    const rawValue = pair.slice(index + 1).trim();
+    if (!rawValue) {
+      map.set(name, '');
+      continue;
+    }
+    try {
+      map.set(name, decodeURIComponent(rawValue));
+    } catch {
+      map.set(name, rawValue);
+    }
+  }
+
+  return map;
+}
+
+export function extractAccessToken(req) {
+  const header = req?.headers?.authorization || '';
+  if (typeof header === 'string' && header.startsWith('Bearer ')) {
+    return header.slice(7);
+  }
+
+  const cookieHeader = req?.headers?.cookie;
+  const cookies = parseCookies(cookieHeader);
+  return cookies.get(COOKIE_NAME) || null;
+}
+
+function resolveExpiry(token) {
+  const decoded = jwt.decode(token);
+  if (!decoded || typeof decoded !== 'object' || !decoded.exp) {
+    return null;
+  }
+  const expMs = decoded.exp * 1000;
+  const msUntilExpiry = Math.max(0, expMs - Date.now());
+  return { expires: new Date(expMs), maxAge: msUntilExpiry || undefined };
+}
+
+export function setAccessTokenCookie(res, token) {
+  if (!token) {
+    throw new Error('ACCESS_TOKEN_REQUIRED');
+  }
+  const expiry = resolveExpiry(token);
+  const options = {
+    httpOnly: true,
+    sameSite: 'strict',
+    secure: isSecureEnv(),
+    path: '/',
+    ...(expiry ?? {}),
+  };
+  res.cookie(COOKIE_NAME, token, options);
+}
+
+export function clearAccessTokenCookie(res) {
+  const options = {
+    httpOnly: true,
+    sameSite: 'strict',
+    secure: isSecureEnv(),
+    path: '/',
+  };
+  res.clearCookie(COOKIE_NAME, options);
+}
+
+export { COOKIE_NAME };

--- a/server/src/util/sanitizeBase64.js
+++ b/server/src/util/sanitizeBase64.js
@@ -1,0 +1,43 @@
+import base64Regex from './base64Regex.js';
+
+const DEFAULT_MIN_LENGTH = 16;
+const DEFAULT_MAX_LENGTH = 512;
+
+export default function sanitizeBase64(
+  value,
+  { minLength = DEFAULT_MIN_LENGTH, maxLength = DEFAULT_MAX_LENGTH, maxBytes } = {}
+) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed !== value) {
+    return null;
+  }
+  if (trimmed.length < minLength || trimmed.length > maxLength) {
+    return null;
+  }
+  if (trimmed.length % 4 !== 0) {
+    return null;
+  }
+  if (!base64Regex.test(trimmed)) {
+    return null;
+  }
+
+  try {
+    const decoded = Buffer.from(trimmed, 'base64');
+    if (decoded.length === 0) {
+      return null;
+    }
+    if (typeof maxBytes === 'number' && maxBytes > 0 && decoded.length > maxBytes) {
+      return null;
+    }
+    if (decoded.toString('base64') !== trimmed) {
+      return null;
+    }
+    return trimmed;
+  } catch {
+    return null;
+  }
+}

--- a/server/test/auth.login.test.js
+++ b/server/test/auth.login.test.js
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import supertest from 'supertest';
+
+import { createApp } from '../src/app.js';
+
+let mongod;
+let request;
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+
+test('setup login fixtures', async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri('auth-login'));
+
+  const app = createApp();
+  request = supertest(app);
+
+  const registerPayload = {
+    username: 'login-user',
+    email: 'login@example.com',
+    password: 'LoginPass123',
+    publicKey: Buffer.from('login-public-key').toString('base64'),
+  };
+
+  const res = await request.post('/api/auth/register').send(registerPayload);
+  assert.equal(res.statusCode, 201);
+});
+
+test('login accepts uppercase email and sets session cookie', async () => {
+  const res = await request.post('/api/auth/login').send({
+    email: 'LOGIN@EXAMPLE.COM',
+    password: 'LoginPass123',
+  });
+
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.body?.userId);
+  const cookies = res.headers['set-cookie'] || [];
+  assert.ok(
+    cookies.some((cookie) => /^access_token=/i.test(cookie)),
+    'access_token cookie must be present'
+  );
+  const cookieHeader = cookies.find((cookie) => /^access_token=/i.test(cookie));
+  assert.ok(cookieHeader, 'cookie header missing');
+
+  const session = await request.get('/api/auth/session').set('Cookie', cookieHeader);
+  assert.equal(session.statusCode, 200);
+  assert.equal(session.body?.userId, res.body.userId);
+
+  const logout = await request.post('/api/auth/logout').set('Cookie', cookieHeader);
+  assert.equal(logout.statusCode, 204);
+  const clearedCookies = logout.headers['set-cookie'] || [];
+  assert.ok(
+    clearedCookies.some((cookie) => /^access_token=;/i.test(cookie) || /Max-Age=0/i.test(cookie)),
+    'logout must clear cookie'
+  );
+
+  const afterLogout = await request.get('/api/auth/session');
+  assert.equal(afterLogout.statusCode, 401);
+});
+
+test('login rejects malformed email', async () => {
+  const res = await request.post('/api/auth/login').send({
+    email: 'not-an-email',
+    password: 'LoginPass123',
+  });
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body?.error, 'invalid_credentials');
+});
+
+test('teardown login fixtures', async () => {
+  await mongoose.disconnect();
+  if (mongod) {
+    await mongod.stop();
+  }
+});

--- a/server/test/auth.register.test.js
+++ b/server/test/auth.register.test.js
@@ -14,7 +14,7 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'test';
 
 test('setup register fixtures', async () => {
   mongod = await MongoMemoryServer.create();
-  await mongoose.connect(mongod.getUri('auth-register')); 
+  await mongoose.connect(mongod.getUri('auth-register'));
 
   const app = createApp();
   request = supertest(app);
@@ -25,20 +25,51 @@ test('register rejects duplicate usernames', async () => {
     username: 'duplicate-user',
     email: 'first@example.com',
     password: 'StrongPass123',
-    publicKey: 'first-public-key',
+    publicKey: Buffer.from('first-public-key').toString('base64'),
   };
 
   const first = await request.post('/api/auth/register').send(basePayload);
   assert.equal(first.statusCode, 201);
+  const cookies = first.headers['set-cookie'] || [];
+  assert.ok(
+    cookies.some((cookie) => /^access_token=/i.test(cookie)),
+    'access_token cookie must be issued on registration'
+  );
 
   const second = await request.post('/api/auth/register').send({
     ...basePayload,
     email: 'second@example.com',
-    publicKey: 'second-public-key',
+    publicKey: Buffer.from('second-public-key').toString('base64'),
   });
 
   assert.equal(second.statusCode, 400);
   assert.equal(second.body?.error, 'user_exists');
+});
+
+test('register rejects invalid email and public key', async () => {
+  const payload = {
+    username: 'bad-user',
+    email: 'not-an-email',
+    password: 'StrongPass123',
+    publicKey: 'not-base64',
+  };
+
+  const res = await request.post('/api/auth/register').send(payload);
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body?.error, 'invalid_fields');
+});
+
+test('register rejects too-short username', async () => {
+  const payload = {
+    username: 'xy',
+    email: 'short@example.com',
+    password: 'StrongPass123',
+    publicKey: Buffer.from('short-user').toString('base64'),
+  };
+
+  const res = await request.post('/api/auth/register').send(payload);
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body?.error, 'invalid_fields');
 });
 
 test('teardown register fixtures', async () => {

--- a/server/test/keybundle.validation.test.js
+++ b/server/test/keybundle.validation.test.js
@@ -6,8 +6,10 @@ import mongoose from 'mongoose';
 import supertest from 'supertest';
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.KEYBUNDLE_MAX_PREKEYS = '5';
 
 const { createApp } = await import('../src/app.js');
+const { default: KeyBundle } = await import('../src/models/KeyBundle.js');
 
 let mongod;
 let app;
@@ -19,12 +21,15 @@ function authStub(req, _res, next) {
   next();
 }
 
+const VALID_KEY = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
+const VALID_SIGNATURE = 'c2lnbmF0dXJlMDEyMzQ1Njc4OWFiY2RlZnNpZ25hdHVyZTAxMjM0NTY3ODlhYmNkZWY=';
+
 const basePayload = {
-  identityKey: 'QUJDRA==',
+  identityKey: VALID_KEY,
   signedPreKey: {
     keyId: 1,
-    publicKey: 'QUJDRA==',
-    signature: 'QUJDRA==',
+    publicKey: VALID_KEY,
+    signature: VALID_SIGNATURE,
   },
 };
 
@@ -37,11 +42,13 @@ test('setup', async () => {
 
 test('rejects invalid one-time pre-key payloads', async () => {
   const cases = [
-    [{ keyId: '1', publicKey: 'QUJDRA==' }],
+    [],
+    [{ keyId: '1', publicKey: VALID_KEY }],
     [{ keyId: 1 }],
     [{ keyId: 1, publicKey: '' }],
     [{ keyId: 1, publicKey: 'not-base64!!' }],
-    [{ keyId: -1, publicKey: 'QUJDRA==' }],
+    [{ keyId: -1, publicKey: VALID_KEY }],
+    Array.from({ length: 10 }, (_, idx) => ({ keyId: idx, publicKey: VALID_KEY })),
   ];
 
   for (const invalid of cases) {
@@ -53,6 +60,52 @@ test('rejects invalid one-time pre-key payloads', async () => {
     assert.equal(res.statusCode, 400);
     assert.equal(res.body.error, 'invalid_payload');
   }
+});
+
+test('rejects invalid identity or signed pre-key payloads', async () => {
+  const invalidRequests = [
+    { ...basePayload, identityKey: 'not-base64' },
+    { ...basePayload, identityKey: '   ' + VALID_KEY },
+    { ...basePayload, signedPreKey: { ...basePayload.signedPreKey, keyId: -5 } },
+    { ...basePayload, signedPreKey: { ...basePayload.signedPreKey, publicKey: 'bad' } },
+    { ...basePayload, signedPreKey: { ...basePayload.signedPreKey, signature: 'bad' } },
+  ];
+
+  for (const payload of invalidRequests) {
+    const res = await request.post('/api/keybundle').send({
+      ...payload,
+      oneTimePreKeys: [],
+    });
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.body.error, 'invalid_payload');
+  }
+});
+
+test('deduplicates one-time pre-keys before persisting', async () => {
+  const bundle = {
+    ...basePayload,
+    oneTimePreKeys: [
+      { keyId: 1, publicKey: VALID_KEY },
+      { keyId: 1, publicKey: VALID_KEY },
+      { keyId: 2, publicKey: 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZTA=' },
+      { keyId: 2, publicKey: 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZTA=' },
+    ],
+  };
+
+  const res = await request.post('/api/keybundle').send(bundle);
+  assert.equal(res.statusCode, 204);
+
+  const stored = await KeyBundle.findOne({ userId }).lean();
+  assert.ok(stored);
+  assert.equal(stored.oneTimePreKeys.length, 2);
+  assert.deepEqual(
+    stored.oneTimePreKeys.map(({ keyId, publicKey }) => ({ keyId, publicKey })),
+    [
+      { keyId: 1, publicKey: VALID_KEY },
+      { keyId: 2, publicKey: 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZTA=' },
+    ]
+  );
 });
 
 test('teardown', async () => {


### PR DESCRIPTION
## Summary
- move authentication state from localStorage to HttpOnly cookies and expose a session probe endpoint for the client
- update the Express auth routes, middleware, and Socket.IO handshake to consume cookie-based tokens while keeping header support for tools
- refresh client context/routing, documentation, tests, and the load processor helper to reflect the new session model

## Testing
- node --test server/test/auth.login.test.js server/test/auth.register.test.js server/test/keybundle.validation.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f5322f1dc8326af830440ab61e85c)